### PR TITLE
Improved version lookup

### DIFF
--- a/__tests__/get-version.test.ts
+++ b/__tests__/get-version.test.ts
@@ -8,6 +8,14 @@ describe("version lookup", () => {
     expect(version).toBe("5.4.2");
   });
 
+  it("identifies version from swift version with target", async () => {
+    const version = versionFromString(
+      `Apple Swift version 5.5 (swiftlang-1300.0.31.1 clang-1300.0.29.1)
+Target: x86_64-apple-macosx11.0`
+    );
+    expect(version).toBe("5.5");
+  });
+
   it("identifies version from swift-driver version", async () => {
     const version = versionFromString(
       "swift-driver version: 1.26.9 Apple Swift version 5.5 (swiftlang-1300.0.31.1 clang-1300.0.29.1)"

--- a/src/get-version.ts
+++ b/src/get-version.ts
@@ -20,8 +20,8 @@ export async function getVersion(
 
   await exec(command, args, options);
 
-  if (error) {
-    throw new Error(error);
+  if (!output && error) {
+    throw new Error("Error getting swift version " + error);
   }
 
   return versionFromString(output);


### PR DESCRIPTION
So swift now reports versions differently causing issues when looking up the currently installed version.