### PR TITLE
Add new OS versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         swift: ["5.7"]
         include:
+        - os: macos-12
+          swift: "5.7"
+        - os: ubuntu-22.04
+          swift: "5.7"
         - os: windows-latest
           swift: "5.6.3"
     steps:

--- a/src/os.ts
+++ b/src/os.ts
@@ -13,8 +13,8 @@ export namespace OS {
 }
 
 const AVAILABLE_OS: { [platform: string]: string[] } = {
-  macOS: ["latest", "11.0", "10.15"],
-  Ubuntu: ["latest", "20.04", "18.04", "16.04"],
+  macOS: ["latest", "12.0", "11.0", "10.15"],
+  Ubuntu: ["latest", "22.04", "20.04", "18.04", "16.04"],
   Windows: ["latest", "10"],
 };
 


### PR DESCRIPTION
This adds new OS versions for macOS (12) and Ubuntu (22.04). Both are currently supported by GitHub actions.