### PR TITLE
BREAKING: Bump Node to 16

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ outputs:
   version:
     description: The full Swift version that was configured
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
 branding:
   icon: 'command'  

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,10 @@
         "prettier": "^2.7.1",
         "ts-jest": "^26.5.6",
         "typescript": "^4.8.4"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Set up GitHub Actions workflow with Swift support",
   "private": true,
   "main": "lib/main.js",
+  "engines": {
+    "node": ">=16.0.0",
+    "npm": ">=8.0.0"
+  },
   "scripts": {
     "build": "tsc",
     "pack": "ncc build",


### PR DESCRIPTION
Github Actions are deprecating the use of Node12 in Actions.

Fixes: #484