### PR TITLE
chore: Replace zeit/ncc with vercel/ncc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@types/jest": "^27.5.0",
         "@types/node": "^18.7.18",
         "@types/semver": "^7.3.12",
-        "@zeit/ncc": "^0.22.3",
+        "@vercel/ncc": "^0.34.0",
         "jest": "^26.6.3",
         "prettier": "^2.7.1",
         "ts-jest": "^26.5.6",
@@ -1107,11 +1107,10 @@
       "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
       "dev": true
     },
-    "node_modules/@zeit/ncc": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.22.3.tgz",
-      "integrity": "sha512-jnCLpLXWuw/PAiJiVbLjA8WBC0IJQbFeUwF4I9M+23MvIxTxk5pD4Q8byQBSPmHQjz5aBoA7AKAElQxMpjrCLQ==",
-      "deprecated": "@zeit/ncc is no longer maintained. Please use @vercel/ncc instead.",
+    "node_modules/@vercel/ncc": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.34.0.tgz",
+      "integrity": "sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==",
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
@@ -7428,10 +7427,10 @@
       "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
       "dev": true
     },
-    "@zeit/ncc": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.22.3.tgz",
-      "integrity": "sha512-jnCLpLXWuw/PAiJiVbLjA8WBC0IJQbFeUwF4I9M+23MvIxTxk5pD4Q8byQBSPmHQjz5aBoA7AKAElQxMpjrCLQ==",
+    "@vercel/ncc": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.34.0.tgz",
+      "integrity": "sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==",
       "dev": true
     },
     "abab": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/jest": "^27.5.0",
     "@types/node": "^18.7.18",
     "@types/semver": "^7.3.12",
-    "@zeit/ncc": "^0.22.3",
+    "@vercel/ncc": "^0.34.0",
     "jest": "^26.6.3",
     "prettier": "^2.7.1",
     "ts-jest": "^26.5.6",


### PR DESCRIPTION
`@zeit/ncc` is deprecated as per: https://www.npmjs.com/package/@zeit/ncc

Recommended to replace with `@vercel/ncc`.