### PR TITLE
Add parsing Swift version from file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,8 +4,9 @@ author: Frederik Wallner
 inputs:
   swift-version: 
     description: Swift version to configure
-    required: true
-    default: '5.9.2'
+  swift-version-file:
+    description: File containing the Swift version
+    default: ".swift-version"
 outputs:
   version:
     description: The full Swift version that was configured

--- a/src/get-requested-version.ts
+++ b/src/get-requested-version.ts
@@ -1,0 +1,52 @@
+import * as core from "@actions/core";
+
+import { readFile } from "fs";
+import { join } from "path";
+
+const semverRegex = /^((?:\d+)(?:\.\d+){0,2})$/;
+
+async function readVersionFromFile(filePath: string) {
+  let version = "";
+
+  readFile(filePath, "utf8", (err, data) => {
+    if (err != null) throw err;
+
+    const parsedVersion = data.match(semverRegex)?.at(1);
+
+    if (parsedVersion == null)
+      throw new Error(
+        `Version provided at ${filePath} is in an unexpected format. Please refer to README.md when providing versions.`
+      );
+
+    version = parsedVersion;
+  });
+
+  return version;
+}
+
+export async function getRequestedVersion(): Promise<string> {
+  const swiftVersion = core.getInput("swift-version");
+  const swiftVersionFile = core.getInput("swift-version-file");
+
+  if (swiftVersion !== "" && swiftVersionFile !== "")
+    core.warning(
+      "Both swift-version as swift-version-file are set. Continuing with swift-version."
+    );
+
+  if (swiftVersion) {
+    return swiftVersion;
+  }
+
+  if (swiftVersionFile) {
+    const versionFilePath = join(
+      process.env.GITHUB_WORKSPACE!,
+      swiftVersionFile
+    );
+
+    return readVersionFromFile(versionFilePath);
+  }
+
+  throw new Error(
+    "Please set swift-version or swift-version-file in the action's configuration."
+  );
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,15 +1,17 @@
 import { EOL } from "os";
 import * as core from "@actions/core";
+
 import * as system from "./os";
 import * as versions from "./swift-versions";
 import * as macos from "./macos-install";
 import * as linux from "./linux-install";
 import * as windows from "./windows-install";
 import { getVersion } from "./get-version";
+import { getRequestedVersion } from "./get-requested-version";
 
 async function run() {
   try {
-    const requestedVersion = core.getInput("swift-version", { required: true });
+    const requestedVersion = await getRequestedVersion();
 
     let platform = await system.getSystem();
     let version = versions.verify(requestedVersion, platform);


### PR DESCRIPTION
This PR closes issue #633

### ✏️ Changes
- **Breaking** | Remove the default Swift version and make it optional (`swift-version`)
- Read Swift version from a file specified in the action's configuration (`swift-version-file`)

### 📝 TODO
- Add tests