### PR TITLE
Update available OSes to match available runner images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,6 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         swift: ["5.10"]
         include:
-        - os: macos-12
-          swift: "5.10"
-        - os: ubuntu-22.04
-          swift: "5.10"
         - os: windows-latest
           swift: "5.6.3"
     steps:

--- a/__tests__/os.test.ts
+++ b/__tests__/os.test.ts
@@ -6,11 +6,11 @@ const setSystem = require("getos").__setSystem;
 
 describe("os resolver", () => {
   it("finds matching system and version", async () => {
-    setSystem({ os: "linux", dist: "Ubuntu", release: "18.04" });
+    setSystem({ os: "linux", dist: "Ubuntu", release: "22.04" });
 
     let ubuntu = await os.getSystem();
     expect(ubuntu.os).toBe(os.OS.Ubuntu);
-    expect(ubuntu.version).toBe("18.04");
+    expect(ubuntu.version).toBe("22.04");
     expect(ubuntu.name).toBe("Ubuntu");
 
     setSystem({ os: "darwin", dist: "macOS", release: "latest" });

--- a/src/os.ts
+++ b/src/os.ts
@@ -13,8 +13,8 @@ export namespace OS {
 }
 
 const AVAILABLE_OS: { [platform: string]: string[] } = {
-  macOS: ["latest", "12.0", "11.0", "10.15"],
-  Ubuntu: ["latest", "22.04", "20.04", "18.04", "16.04"],
+  macOS: ["latest", "14", "13", "12", "11"],
+  Ubuntu: ["latest", "24.04", "22.04", "20.04"],
   Windows: ["latest", "10"],
 };
 


### PR DESCRIPTION
Currently available runner images are listed at https://github.com/actions/runner-images?tab=readme-ov-file#available-images. 

- macos-10, ubuntu-18.04 and ubuntu-16.04 are no longer available and have been removed.
- macos-11 now corresponds to OS version 11.7 and macos-12 now corresponds to OS version 12.7, so the minor versions have been removed from the macOS list.
- ubuntu-24.04 is now available in beta so it has been added to the Ubuntu platform list. 

The change is along the lines of #473 when ubuntu-22.04 was added so 🤞 this works.

Fixes https://github.com/swift-actions/setup-swift/issues/674.

I also made an update to the integration test matrix, see comments separately.