### PR TITLE
New Windows support (setup-swift 3.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
+        os:
+          [
+            ubuntu-latest,
+            ubuntu-24.04-arm,
+            macos-latest,
+            windows-latest,
+            windows-11-arm,
+          ]
         swift: ["6.1"]
     steps:
       - uses: actions/checkout@v4
@@ -36,6 +43,9 @@ jobs:
           node-version-file: ".nvmrc"
       - run: npm install
       - run: npm run build && npm run pack-source-map
+      - name: Add msbuild to PATH
+        if: ${{ matrix.os == 'windows-latest' || matrix.os == 'windows-11-arm' }}
+        uses: microsoft/setup-msbuild@v2
       - uses: ./
         with:
           swift-version: ${{ matrix.swift }}

--- a/src/windows/windows.ts
+++ b/src/windows/windows.ts
@@ -9,5 +9,44 @@ import { coerce } from "semver";
  * Setup Swift on Windows as theres no support for Swiftly yet.
  */
 export async function setupWindows(version: string) {
-  throw Error("Windows is not supported yet");
+  const path = await download(version);
+  addPath(path);
+}
+
+async function download(version: string) {
+  const m = machine();
+
+  let url: string;
+  if (m === "arm64") {
+    url = `https://download.swift.org/swift-${version}-release/windows10-arm64/swift-${version}-RELEASE/swift-${version}-RELEASE-windows10-arm64.exe`;
+  } else {
+    url = `https://download.swift.org/swift-${version}-release/windows10/swift-${version}-RELEASE/swift-${version}-RELEASE-windows10.exe`;
+  }
+
+  debug(`Downloading Swift installer from ${url}`);
+
+  const tmpPath = tempDir();
+
+  const installerPath = await downloadTool(
+    url,
+    join(tmpPath, "swift-installer.exe"),
+  );
+
+  const targetPath = join(tmpPath, "Swift");
+
+  await cmd(
+    installerPath,
+    "/passive",
+    "/quiet",
+    "/norestart",
+    `InstallRoot=${targetPath}`,
+  );
+
+  return join(
+    targetPath,
+    "Toolchains",
+    `${coerce(version)}+Asserts`,
+    "usr",
+    "bin",
+  );
 }


### PR DESCRIPTION
Derived from https://github.com/swift-actions/setup-swift/pull/710 to focus on only Windows