### PR TITLE
Avoid redirection by using `https://www.swift.org/keys/all-keys.asc`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -78,7 +78,7 @@ const core = __importStar(__nccwpck_require__(2186));
 const toolCache = __importStar(__nccwpck_require__(7784));
 async function setupKeys() {
     core.debug("Fetching verification keys");
-    let path = await toolCache.downloadTool("https://swift.org/keys/all-keys.asc");
+    let path = await toolCache.downloadTool("https://www.swift.org/keys/all-keys.asc");
     core.debug("Importing verification keys");
     await (0, exec_1.exec)(`gpg --import "${path}"`);
     core.debug("Refreshing keys");


### PR DESCRIPTION
This PR aims to reduce the flakiness of GPG key downloading.

```
gpg: directory '/home/runner/.gnupg' created
gpg: keybox '/home/runner/.gnupg/pubring.kbx' created
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
Error: Unexpected error, unable to continue. Please report at https://github.com/swift-actions/setup-swift/issues
The process '/usr/bin/gpg' failed with exit code 2
Stacktrace:
Error: The process '/usr/bin/gpg' failed with exit code 2
    at ExecState._setResult (/home/runner/work/_actions/swift-actions/setup-swift/d10500c1ac8822132eebbd74c48c3372c71d7ff5/dist/index.js:3197:25)
```

`https://swift.org/keys/all-keys.asc` is moved to `https://www.swift.org/keys/all-keys.asc`. It seems to be the root cause of the flakiness. We had better use the direct destination.

```
$ curl -v https://swift.org/keys/all-keys.asc
* Host swift.org:443 was resolved.
* IPv6: (none)
* IPv4: 17.253.144.12
*   Trying 17.253.144.12:443...
* Connected to swift.org (17.253.144.12) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
* (304) (IN), TLS handshake, Server hello (2):
* (304) (IN), TLS handshake, Unknown (8):
* (304) (IN), TLS handshake, Certificate (11):
* (304) (IN), TLS handshake, CERT verify (15):
* (304) (IN), TLS handshake, Finished (20):
* (304) (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: C=US; ST=California; O=Apple Inc.; CN=swift.org
*  start date: Apr 22 23:51:45 2025 GMT
*  expire date: Jul 17 19:57:31 2025 GMT
*  issuer: CN=Apple Public Server ECC CA 11 - G1; O=Apple Inc.; ST=California; C=US
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /keys/all-keys.asc HTTP/1.1
> Host: swift.org
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/1.1 302 Redirect
< Date: Fri, 02 May 2025 20:43:43 GMT
< Connection: keep-alive
< Via: http/1.1 usscz2-edge-bx-014.ts.apple.com (acdn/239.16192)
< Cache-Control: no-store
< Location: https://www.swift.org/keys/all-keys.asc
< Content-Type: text/html
< Content-Language: en
< X-Cache: none
< CDNUUID: 02aad556-fbaf-420f-bf3a-adf26a5c5f40-13406434031
< Content-Length: 257
<
<HTML>
<HEAD>
<TITLE>Document Has Moved</TITLE>
</HEAD>

<BODY BGCOLOR="white" FGCOLOR="black">
<H1>Document Has Moved</H1>
<HR>

<FONT FACE="Helvetica,Arial"><B>
Description: The document you requested has moved to a new location.
</B></FONT>
<HR>
</BODY>
* Connection #0 to host swift.org left intact
```