### PR TITLE
Fix GPG key import

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -82,7 +82,7 @@ async function setupKeys() {
     core.debug("Examining verification keys");
     await (0, exec_1.exec)(`file "${path}"`);
     core.debug("Importing verification keys");
-    await (0, exec_1.exec)(`zcat ${path} | gpg --import -`);
+    await (0, exec_1.exec)('bash', ['-c', `zcat "${path}" | gpg --import`]);
     core.debug("Refreshing keys");
     await refreshKeys();
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -78,7 +78,7 @@ const core = __importStar(__nccwpck_require__(2186));
 const toolCache = __importStar(__nccwpck_require__(7784));
 async function setupKeys() {
     core.debug("Fetching verification keys");
-    let path = await toolCache.downloadTool("https://swift.org/keys/all-keys.asc", undefined, undefined, { "accept-encoding": "identity" });
+    let path = await toolCache.downloadTool("https://swift.org/keys/all-keys.asc");
     core.debug("Examining verification keys");
     await (0, exec_1.exec)(`file "${path}"`);
     core.debug("Importing verification keys");

--- a/dist/index.js
+++ b/dist/index.js
@@ -79,6 +79,10 @@ const toolCache = __importStar(__nccwpck_require__(7784));
 async function setupKeys() {
     core.debug("Fetching verification keys");
     let path = await toolCache.downloadTool("https://swift.org/keys/all-keys.asc");
+    core.debug("Examining verification keys");
+    await (0, exec_1.exec)(`echo "${path}"`);
+    await (0, exec_1.exec)(`file "${path}"`);
+    await (0, exec_1.exec)(`cat "${path}"`);
     core.debug("Importing verification keys");
     await (0, exec_1.exec)(`gpg --import "${path}"`);
     core.debug("Refreshing keys");

--- a/dist/index.js
+++ b/dist/index.js
@@ -80,11 +80,9 @@ async function setupKeys() {
     core.debug("Fetching verification keys");
     let path = await toolCache.downloadTool("https://swift.org/keys/all-keys.asc", undefined, undefined, { "accept-encoding": "identity" });
     core.debug("Examining verification keys");
-    await (0, exec_1.exec)(`echo "${path}"`);
     await (0, exec_1.exec)(`file "${path}"`);
-    await (0, exec_1.exec)(`cat "${path}"`);
     core.debug("Importing verification keys");
-    await (0, exec_1.exec)(`gpg --import "${path}"`);
+    await (0, exec_1.exec)(`zcat ${path} | gpg --import -`);
     core.debug("Refreshing keys");
     await refreshKeys();
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -78,7 +78,7 @@ const core = __importStar(__nccwpck_require__(2186));
 const toolCache = __importStar(__nccwpck_require__(7784));
 async function setupKeys() {
     core.debug("Fetching verification keys");
-    let path = await toolCache.downloadTool("https://swift.org/keys/all-keys.asc");
+    let path = await toolCache.downloadTool("https://swift.org/keys/all-keys.asc", undefined, undefined, { "accept-encoding": "identity" });
     core.debug("Examining verification keys");
     await (0, exec_1.exec)(`echo "${path}"`);
     await (0, exec_1.exec)(`file "${path}"`);

--- a/src/gpg.ts
+++ b/src/gpg.ts
@@ -5,7 +5,7 @@ import * as toolCache from "@actions/tool-cache";
 export async function setupKeys() {
   core.debug("Fetching verification keys");
   let path = await toolCache.downloadTool(
-    "https://swift.org/keys/all-keys.asc"
+    "https://swift.org/keys/all-keys.asc", undefined, undefined, {"accept-encoding": "identity"},
   );
 
   core.debug("Examining verification keys");

--- a/src/gpg.ts
+++ b/src/gpg.ts
@@ -12,7 +12,7 @@ export async function setupKeys() {
   await exec(`file "${path}"`);
 
   core.debug("Importing verification keys");
-  await exec(`zcat ${path} | gpg --import -`);
+  await exec('bash', ['-c', `zcat "${path}" | gpg --import`]);
 
   core.debug("Refreshing keys");
   await refreshKeys();

--- a/src/gpg.ts
+++ b/src/gpg.ts
@@ -9,6 +9,7 @@ export async function setupKeys() {
   );
 
   core.debug("Examining verification keys");
+  await exec(`echo "${path}"`);
   await exec(`file "${path}"`);
   await exec(`cat "${path}"`);
 

--- a/src/gpg.ts
+++ b/src/gpg.ts
@@ -9,12 +9,10 @@ export async function setupKeys() {
   );
 
   core.debug("Examining verification keys");
-  await exec(`echo "${path}"`);
   await exec(`file "${path}"`);
-  await exec(`cat "${path}"`);
 
   core.debug("Importing verification keys");
-  await exec(`gpg --import "${path}"`);
+  await exec(`zcat ${path} | gpg --import -`);
 
   core.debug("Refreshing keys");
   await refreshKeys();

--- a/src/gpg.ts
+++ b/src/gpg.ts
@@ -5,7 +5,7 @@ import * as toolCache from "@actions/tool-cache";
 export async function setupKeys() {
   core.debug("Fetching verification keys");
   let path = await toolCache.downloadTool(
-    "https://swift.org/keys/all-keys.asc", undefined, undefined, {"accept-encoding": "identity"},
+    "https://swift.org/keys/all-keys.asc"
   );
 
   core.debug("Examining verification keys");

--- a/src/gpg.ts
+++ b/src/gpg.ts
@@ -8,6 +8,10 @@ export async function setupKeys() {
     "https://swift.org/keys/all-keys.asc"
   );
 
+  core.debug("Examining verification keys");
+  await exec(`file "${path}"`);
+  await exec(`cat "${path}"`);
+
   core.debug("Importing verification keys");
   await exec(`gpg --import "${path}"`);
 


### PR DESCRIPTION
To celebrate Server Side Swift Conference 2025 I am proposing a fix to the long-standing issue where import of Swift signing GPG keys fails.

As identified in multiple bug reports, the root cause is that `downloadTool` fetching the keys from the swift.org website actually stores gzipped file into a temporary directory, and `gpg --import` is unable to cope with that.

Some people suggested that this may be a problem with the CDN sending `deflate` encoding randomly, so I am proposing a robust fix that invokes `zcat` on the downloaded file and then pipes it into `gpg --import` via `stdin`.

Tried on couple runs in my private repositories and it seems to work reliably.

Closes #759, #739, #694, #591, #520, #419.
